### PR TITLE
lwt-osx.5.7.0: fix optional dependency management

### DIFF
--- a/packages/lwt-osx/lwt-osx.5.7.0/opam
+++ b/packages/lwt-osx/lwt-osx.5.7.0/opam
@@ -36,7 +36,7 @@ depopts: [
 
 build: [
   ["dune" "exec" "-p" "lwt" "-x" "osx" "src/unix/config/discover.exe" "--" "--save"
-    "--use-libev" "%{conf-libev:installed}%"]
+    "--use-libev" "%{conf-libev-osx:installed}%"]
   ["dune" "build" "-p" "lwt" "-x" "osx" "-j" jobs]
 ]
 


### PR DESCRIPTION
@ddeclerck I saw this in passing… I think it makes sense. 